### PR TITLE
chore: bump go-coldbrew dependencies to latest releases

### DIFF
--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,9 +11,9 @@ tool (
 )
 
 require (
-	github.com/go-coldbrew/core v0.1.33
-	github.com/go-coldbrew/errors v0.2.5
-	github.com/go-coldbrew/log v0.2.7
+	github.com/go-coldbrew/core v0.1.39
+	github.com/go-coldbrew/errors v0.2.8
+	github.com/go-coldbrew/log v0.2.8
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7


### PR DESCRIPTION
## Summary
- core v0.1.33 -> v0.1.39 (errgroup startup fix, graceful shutdown preservation)
- errors v0.2.5 -> v0.2.8 (race-safe asyncSem, atomic shouldNotify, safe GetTraceId)
- log v0.2.7 -> v0.2.8

## Test plan
- [ ] Generate a new project from the template and verify `go build ./...` succeeds
- [ ] Verify `go test ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core Go module dependencies to latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->