### PR TITLE
chore: bump ColdBrew and dependency versions

### DIFF
--- a/{{cookiecutter.app_name}}/buf.gen.yaml
+++ b/{{cookiecutter.app_name}}/buf.gen.yaml
@@ -1,17 +1,17 @@
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/go:v1.36.5
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: proto
     opt: paths=source_relative
-  - remote: buf.build/grpc/go:v1.5.1
+  - remote: buf.build/grpc/go:v1.6.1
     out: proto
     opt: paths=source_relative,require_unimplemented_servers=false
-  - remote: buf.build/grpc-ecosystem/gateway:v2.26.1
+  - remote: buf.build/grpc-ecosystem/gateway:v2.28.0
     out: proto
     opt: paths=source_relative
-  - remote: buf.build/grpc-ecosystem/openapiv2:v2.26.1
+  - remote: buf.build/grpc-ecosystem/openapiv2:v2.28.0
     out: third_party/OpenAPI
     opt: ""
-  - remote: buf.build/community/planetscale-vtprotobuf:v0.6.0
+  - remote: buf.build/community/planetscale-vtprotobuf:v0.6.1
     out: proto
     opt: paths=source_relative,features=marshal+unmarshal+size+clone+pool+equal

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -13,7 +13,8 @@ tool (
 require (
 	github.com/go-coldbrew/core v0.1.42
 	github.com/go-coldbrew/errors v0.2.11
-	github.com/go-coldbrew/log v0.2.9
+	github.com/go-coldbrew/log v0.3.0
+	github.com/go-coldbrew/options v0.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,8 +11,8 @@ tool (
 )
 
 require (
-	github.com/go-coldbrew/core v0.1.42
-	github.com/go-coldbrew/errors v0.2.11
+	github.com/go-coldbrew/core v0.1.43
+	github.com/go-coldbrew/errors v0.2.12
 	github.com/go-coldbrew/log v0.3.0
 	github.com/go-coldbrew/options v0.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,13 +11,15 @@ tool (
 )
 
 require (
-	github.com/go-coldbrew/core v0.1.33
-	github.com/go-coldbrew/errors v0.2.5
-	github.com/go-coldbrew/log v0.2.7
+	github.com/go-coldbrew/core v0.1.42
+	github.com/go-coldbrew/errors v0.2.11
+	github.com/go-coldbrew/log v0.2.9
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	github.com/stretchr/testify v1.11.1
-	google.golang.org/genproto/googleapis/api v0.0.0-20260319201613-d00831a3d3e7
-	google.golang.org/grpc v1.79.3
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -119,7 +121,9 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
-	github.com/go-coldbrew/options v0.2.6 // indirect
+	github.com/go-coldbrew/interceptors v0.1.17 // indirect
+	github.com/go-coldbrew/options v0.2.7 // indirect
+	github.com/go-coldbrew/tracing v0.2.1 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
@@ -286,10 +290,16 @@ require (
 	go.lsp.dev/protocol v0.12.0 // indirect
 	go.lsp.dev/uri v0.3.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.42.0 // indirect
-	go.opentelemetry.io/otel/metric v1.42.0 // indirect
-	go.opentelemetry.io/otel/trace v1.42.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/bridge/opentracing v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
@@ -306,7 +316,7 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	golang.org/x/vuln v1.1.4 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## Summary
- Bump core v0.1.33 → v0.1.42 (unix socket gateway, ServeMux, pool statusRecorder)
- Bump errors v0.2.5 → v0.2.11 (trace ID validation, SetTraceIDValidator)
- Bump log v0.2.7 → v0.2.9 (slog default, RWMutex+map)
- Bump grpc v1.79.3 → v1.80.0
- Add grpc-gateway v2.28.0 and vtprotobuf as direct deps
- Bump interceptors, options, tracing, OpenTelemetry, genproto indirects

## Test plan
- [x] Versions match latest releases across all go-coldbrew packages
- [ ] Generate a new service from template and verify `go mod tidy && go build ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated primary and indirect dependencies to newer, more secure releases.
  * Upgraded the gRPC stack and related runtime libraries for improved stability and compatibility.
  * Updated OpenTelemetry SDKs, exporters, and instrumentation for enhanced tracing and telemetry.
  * Added gRPC gateway and vtprotobuf runtime dependencies to broaden API stack support.
  * Bumped protocol buffer and code-generation plugin versions for generator improvements and bug fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->