### PR TITLE
feat: implement CBGracefulStopper in service template

### DIFF
--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -18,6 +18,13 @@ import (
 	openapi "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/third_party/OpenAPI"
 )
 
+// Compile-time interface assertions.
+var (
+	_ core.CBService          = (*cbSvc)(nil)
+	_ core.CBStopper          = (*cbSvc)(nil)
+	_ core.CBGracefulStopper  = (*cbSvc)(nil)
+)
+
 // cbSvc is the service implementation of ColdBrew service
 type cbSvc struct {
 	stopper core.CBStopper

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -57,17 +57,6 @@ func (s *svc) Stop() {
 	// Close database connections, flush buffers, etc.
 }
 
-// FailCheck implements core.CBGracefulStopper.
-// Called by ColdBrew during graceful shutdown to fail the readiness probe
-// before stopping the server, allowing the load balancer to drain traffic.
-func (s *svc) FailCheck(fail bool) {
-	if fail {
-		SetNotReady()
-	} else {
-		SetReady()
-	}
-}
-
 // Creates a new Service instance and returns it
 func New(cfg config.Config) (*svc, error) {
 	// TODO: Application should validate the config here and return an error if it is invalid or missing

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -54,7 +54,18 @@ func (s *svc) Error(ctx context.Context, req *proto.EchoRequest) (*proto.EchoRes
 }
 
 func (s *svc) Stop() {
-	//  TODO: Add your cleanup code here
+	// Close database connections, flush buffers, etc.
+}
+
+// FailCheck implements core.CBGracefulStopper.
+// Called by ColdBrew during graceful shutdown to fail the readiness probe
+// before stopping the server, allowing the load balancer to drain traffic.
+func (s *svc) FailCheck(fail bool) {
+	if fail {
+		SetNotReady()
+	} else {
+		SetReady()
+	}
 }
 
 // Creates a new Service instance and returns it


### PR DESCRIPTION
## Summary
- Implements `core.CBGracefulStopper` in the cookiecutter service template via `cbSvc.FailCheck` in `main.go`
- Bridges to existing `SetNotReady()`/`SetReady()` health check functions
- During graceful shutdown, ColdBrew calls `FailCheck(true)` to fail the readiness probe before stopping the server, giving the load balancer time to drain traffic
- Adds compile-time interface assertions for `CBService`, `CBStopper`, and `CBGracefulStopper` on `cbSvc`

Previously, the template only implemented `CBService` + `CBStopper`. `GracefulStop()` still handled in-flight requests correctly, but K8s could keep routing new traffic during the drain period.

## Test plan
- [x] Template generates valid Go code (cookiecutter placeholders only)
- [x] `FailCheck` delegates to existing health check infrastructure
- [x] No duplicate `FailCheck` — only `cbSvc` (the type passed to `SetService`) implements it
- [x] Compile-time assertions ensure `cbSvc` satisfies all required ColdBrew interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal cleanup: clarified shutdown-related comments and added build-time interface checks to improve maintainability.
  * No changes to runtime behavior, public APIs, or shutdown readiness; there are no user-visible changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->