### PR TITLE
chore: bump core to v0.1.45, interceptors to v0.1.20

### DIFF
--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,6 +11,7 @@ tool (
 )
 
 require (
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
 	github.com/go-coldbrew/core v0.1.45
 	github.com/go-coldbrew/errors v0.2.13
 	github.com/go-coldbrew/log v0.3.1
@@ -28,7 +29,6 @@ require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
 	buf.build/gen/go/bufbuild/bufplugin/protocolbuffers/go v1.36.11-20250718181942-e35f9b667443.1 // indirect
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 // indirect
 	buf.build/gen/go/bufbuild/registry/connectrpc/go v1.19.1-20260126144947-819582968857.2 // indirect
 	buf.build/gen/go/bufbuild/registry/protocolbuffers/go v1.36.11-20260126144947-819582968857.1 // indirect
 	buf.build/gen/go/pluginrpc/pluginrpc/protocolbuffers/go v1.36.11-20241007202033-cf42259fcbfc.1 // indirect

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,7 +11,7 @@ tool (
 )
 
 require (
-	github.com/go-coldbrew/core v0.1.44
+	github.com/go-coldbrew/core v0.1.45
 	github.com/go-coldbrew/errors v0.2.13
 	github.com/go-coldbrew/log v0.3.1
 	github.com/go-coldbrew/options v0.3.0
@@ -122,7 +122,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
-	github.com/go-coldbrew/interceptors v0.1.17 // indirect
+	github.com/go-coldbrew/interceptors v0.1.20 // indirect
 	github.com/go-coldbrew/options v0.2.7 // indirect
 	github.com/go-coldbrew/tracing v0.2.1 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect


### PR DESCRIPTION
## Summary
- Bump core v0.1.44 → v0.1.45 (DISABLE_PROTO_VALIDATE config)
- Bump interceptors v0.1.17 → v0.1.20 (protovalidate in default chain)

## Test plan
- [x] go.mod versions correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->