### PR TITLE
feat: add GOPRIVATE support for private Go modules

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "app_name": "{{cookiecutter.name | replace(' ', '_') | lower}}",
   "grpc_package": "com.github.ankurs",
   "service_name": "MySvc",
-  "goprivate": "{{cookiecutter.source_path}}/*",
+  "goprivate": "",
   "project_short_description": "{{cookiecutter.name}} is a Golang project.",
   "docker_image": "alpine:latest",
   "docker_build_image": "golang",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
   "app_name": "{{cookiecutter.name | replace(' ', '_') | lower}}",
   "grpc_package": "com.github.ankurs",
   "service_name": "MySvc",
+  "goprivate": "{{cookiecutter.source_path}}/*",
   "project_short_description": "{{cookiecutter.name}} is a Golang project.",
   "docker_image": "alpine:latest",
   "docker_build_image": "golang",

--- a/{{cookiecutter.app_name}}/.github/workflows/go.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/go.yml
@@ -9,6 +9,15 @@ on:
   pull_request:
     branches: [ "main" , "master"]
 
+env:
+  GOPRIVATE: {{cookiecutter.goprivate}}
+
+# Uncomment for private Go modules:
+#   - name: Configure private modules
+#     run: git config --global url."https://x-access-token:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+#     env:
+#       GITHUB_TOKEN: {% raw %}${{ secrets.GO_PRIVATE_TOKEN }}{% endraw %}
+
 jobs:
   build:
     concurrency:

--- a/{{cookiecutter.app_name}}/.github/workflows/go.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/go.yml
@@ -10,13 +10,7 @@ on:
     branches: [ "main" , "master"]
 
 env:
-  GOPRIVATE: {{cookiecutter.goprivate}}
-
-# Uncomment for private Go modules:
-#   - name: Configure private modules
-#     run: git config --global url."https://x-access-token:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
-#     env:
-#       GITHUB_TOKEN: {% raw %}${{ secrets.GO_PRIVATE_TOKEN }}{% endraw %}
+  GOPRIVATE: "{{cookiecutter.goprivate}}"
 
 jobs:
   build:
@@ -26,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    # Uncomment for private Go modules:
+    # - name: Configure private modules
+    #   run: git config --global url."https://x-access-token:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+    #   env:
+    #     GITHUB_TOKEN: {% raw %}${{ secrets.GO_PRIVATE_TOKEN }}{% endraw %}
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/{{cookiecutter.app_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.app_name}}/.gitlab-ci.yml
@@ -4,11 +4,14 @@ image: "golang:{{cookiecutter.docker_build_image_version}}"
   variables: &go_variables
     GOFLAGS: "-mod=readonly"
     GOMODCACHE: "$CI_PROJECT_DIR/.go/pkg/mod"
+    GOPRIVATE: "{{cookiecutter.goprivate}}"
   cache:
     paths:
       - .go/pkg/mod/
   before_script:
     - mkdir -p .go/pkg/mod
+    # Uncomment for private Go modules:
+    # - echo "machine gitlab.com login gitlab-ci-token password ${CI_JOB_TOKEN}" > ~/.netrc
 
 .only_production: &only_production
   refs:

--- a/{{cookiecutter.app_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.app_name}}/.gitlab-ci.yml
@@ -11,7 +11,7 @@ image: "golang:{{cookiecutter.docker_build_image_version}}"
   before_script:
     - mkdir -p .go/pkg/mod
     # Uncomment for private Go modules:
-    # - echo "machine gitlab.com login gitlab-ci-token password ${CI_JOB_TOKEN}" > ~/.netrc
+    # - echo "machine gitlab.com login gitlab-ci-token password ${CI_JOB_TOKEN}" > ~/.netrc && chmod 600 ~/.netrc
 
 .only_production: &only_production
   refs:

--- a/{{cookiecutter.app_name}}/AGENTS.md
+++ b/{{cookiecutter.app_name}}/AGENTS.md
@@ -95,6 +95,14 @@ make run-docker      # Run in Docker container
 - Create the service with `New(config.Get())` to test with real config
 - Benchmarks use `func BenchmarkX(b *testing.B)` with `b.ResetTimer()` before the hot loop
 
+### Private modules
+
+GOPRIVATE is pre-configured in Makefile, Dockerfile, and CI workflows. For private repos:
+- **Local dev**: `git config --global url."git@github.com:".insteadOf "https://github.com/"` (SSH) or add a `.netrc` with a PAT
+- **Docker**: uncomment the auth section in `Dockerfile`
+- **CI**: uncomment the auth steps in `.github/workflows/go.yml` or `.gitlab-ci.yml`
+- See [Private Modules guide](https://docs.coldbrew.cloud/howto/private-modules/) for details
+
 ## Rules
 
 - **Never edit generated files** — files in `proto/*.pb.go`, `proto/*_grpc.pb.go`, `proto/*.gw.go` are generated. Edit the `.proto` file and run `make generate`.

--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -8,14 +8,15 @@ ARG GOPRIVATE={{cookiecutter.goprivate}}
 ENV GOPRIVATE=${GOPRIVATE}
 
 # --- Private module authentication (uncomment one) ---
-# Option 1: SSH key (mount host SSH agent or key)
-# RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
-# Option 2: .netrc with personal access token (GitHub)
+# Prefer BuildKit secret mounts to avoid baking credentials into image layers.
+# Option 1: SSH (use: DOCKER_BUILDKIT=1 docker build --ssh default .)
+# RUN --mount=type=ssh git config --global url."git@github.com:".insteadOf "https://github.com/"
+# Option 2: .netrc via BuildKit secret (use: docker build --secret id=netrc,src=$HOME/.netrc .)
+# RUN --mount=type=secret,id=netrc,target=/root/.netrc true
+# Option 3: Token via build arg (less secure — visible in image history)
 # ARG GITHUB_TOKEN
-# RUN echo "machine github.com login x-access-token password ${GITHUB_TOKEN}" > ~/.netrc
-# Option 3: .netrc with deploy token (GitLab)
-# ARG GITLAB_TOKEN
-# RUN echo "machine gitlab.com login deploy-token password ${GITLAB_TOKEN}" > ~/.netrc
+# RUN echo "machine github.com login x-access-token password ${GITHUB_TOKEN}" > ~/.netrc && \
+#     make build-alpine && rm -f ~/.netrc
 
 WORKDIR /app
 

--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -4,6 +4,19 @@ FROM {{cookiecutter.docker_build_image}}:{{cookiecutter.docker_build_image_versi
 LABEL app="build-{{cookiecutter.app_name}}"
 LABEL REPO="https://{{cookiecutter.source_path}}/{{cookiecutter.app_name}}"
 
+ARG GOPRIVATE={{cookiecutter.goprivate}}
+ENV GOPRIVATE=${GOPRIVATE}
+
+# --- Private module authentication (uncomment one) ---
+# Option 1: SSH key (mount host SSH agent or key)
+# RUN git config --global url."git@github.com:".insteadOf "https://github.com/"
+# Option 2: .netrc with personal access token (GitHub)
+# ARG GITHUB_TOKEN
+# RUN echo "machine github.com login x-access-token password ${GITHUB_TOKEN}" > ~/.netrc
+# Option 3: .netrc with deploy token (GitLab)
+# ARG GITLAB_TOKEN
+# RUN echo "machine gitlab.com login deploy-token password ${GITLAB_TOKEN}" > ~/.netrc
+
 WORKDIR /app
 
 COPY . .

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build build-alpine clean test default deps generate run run-docker fmt help bench build-docker coverage-html dep lint mock runj vulncheck
 
 BIN_NAME={{cookiecutter.app_name}}
+GOPRIVATE ?= {{cookiecutter.goprivate}}
+export GOPRIVATE
 
 SHELL := $(shell which bash)
 VERSION := $(shell grep "const Version " version/version.go | sed -E 's/.*"(.+)"$$/\1/')

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -49,7 +49,7 @@ build-alpine:
 
 build-docker:
 	@echo "building image ${BIN_NAME} ${VERSION} $(GIT_COMMIT)"
-	docker build --build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GIT_BRANCH=$(GIT_BRANCH) -t $(IMAGE_NAME):local .
+	docker build --build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg GIT_BRANCH=$(GIT_BRANCH) --build-arg GOPRIVATE=$(GOPRIVATE) -t $(IMAGE_NAME):local .
 
 dep:
 	go mod tidy


### PR DESCRIPTION
## Summary
- Add `goprivate` variable to `cookiecutter.json` (defaults to `source_path/*`)
- Pre-configure GOPRIVATE in Makefile, Dockerfile, GitHub Actions, GitLab CI
- Add commented-out auth examples for SSH, PAT, deploy tokens
- Document in AGENTS.md

## Test plan
- [x] Template renders correctly with default goprivate
- [x] Template renders correctly with empty goprivate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable GOPRIVATE setting to the project template and propagated it to local, container build, and CI environments to support private Go modules.
  * CI and build workflows include optional, commented templates to enable authenticated access to private modules.

* **Documentation**
  * Added guidance for configuring and accessing private Go modules in local development, Docker builds, and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->