### PR TITLE
feat: workers delegation and lifecycle hooks

### DIFF
--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -12,9 +12,10 @@ tool (
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
-	github.com/go-coldbrew/core v0.1.51
+	github.com/go-coldbrew/core v0.2.0
 	github.com/go-coldbrew/errors v0.2.15
-	github.com/go-coldbrew/interceptors v0.1.25
+	github.com/go-coldbrew/workers v0.2.1
+	github.com/go-coldbrew/interceptors v0.3.1
 	github.com/go-coldbrew/log v0.4.1
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -12,7 +12,6 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/auth"
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/version"
 	"github.com/go-coldbrew/core"
-	"github.com/go-coldbrew/workers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/swaggest/swgui"
 	"github.com/swaggest/swgui/v5emb"
@@ -22,7 +21,7 @@ import (
 	openapi "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/third_party/OpenAPI"
 )
 
-// Compile-time interface assertions.
+// Compile-time interface assertions — remove or adjust as you customize your service.
 var (
 	_ core.CBService         = (*cbSvc)(nil)
 	_ core.CBStopper         = (*cbSvc)(nil)
@@ -31,18 +30,14 @@ var (
 	_ core.CBWorkerProvider  = (*cbSvc)(nil)
 )
 
-// serviceImpl is the interface that the service implementation must satisfy.
-// It combines cleanup (Stop) with background worker management (Workers).
-type serviceImpl interface {
-	Stop()
-	Workers() []*workers.Worker
-}
-
 // cbSvc is the ColdBrew service adapter. It delegates to the service
 // implementation in service/service.go. Optional interfaces (CBPreStarter,
 // CBWorkerProvider, etc.) are discovered automatically by ColdBrew's Run().
+// impl stores the concrete *service.svc; typed as any so it can be passed
+// to Register*Server and health server registration without exporting the type.
+// Feel free to replace with a concrete or interface type if you prefer stronger typing.
 type cbSvc struct {
-	impl serviceImpl
+	impl any
 }
 
 // FailCheck allows graceful termination of the service
@@ -56,9 +51,10 @@ func (s *cbSvc) FailCheck(fail bool) {
 }
 
 // Stop is called when the service is being stopped by the ColdBrew framework
-// This is a good place to clean up resources and gracefully shutdown the service if needed before the process exits completely
 func (s *cbSvc) Stop() {
-	s.impl.Stop()
+	if impl, ok := s.impl.(interface{ Stop() }); ok {
+		impl.Stop()
+	}
 }
 
 // PreStart is called before gRPC/HTTP servers start. Use this for initialization
@@ -79,7 +75,10 @@ func (s *cbSvc) PreStart(ctx context.Context) error {
 
 // Workers delegates to the service implementation which owns its background workers.
 func (s *cbSvc) Workers() []*workers.Worker {
-	return s.impl.Workers()
+	if impl, ok := s.impl.(interface{ Workers() []*workers.Worker }); ok {
+		return impl.Workers()
+	}
+	return nil
 }
 
 // InitHTTP is called by the ColdBrew framework to initialize the HTTP server and register the HTTP handlers

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -12,6 +12,7 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/auth"
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/version"
 	"github.com/go-coldbrew/core"
+	"github.com/go-coldbrew/workers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/swaggest/swgui"
 	"github.com/swaggest/swgui/v5emb"
@@ -23,14 +24,25 @@ import (
 
 // Compile-time interface assertions.
 var (
-	_ core.CBService          = (*cbSvc)(nil)
-	_ core.CBStopper          = (*cbSvc)(nil)
-	_ core.CBGracefulStopper  = (*cbSvc)(nil)
+	_ core.CBService         = (*cbSvc)(nil)
+	_ core.CBStopper         = (*cbSvc)(nil)
+	_ core.CBGracefulStopper = (*cbSvc)(nil)
+	_ core.CBPreStarter      = (*cbSvc)(nil)
+	_ core.CBWorkerProvider  = (*cbSvc)(nil)
 )
 
-// cbSvc is the service implementation of ColdBrew service
+// serviceImpl is the interface that the service implementation must satisfy.
+// It combines cleanup (Stop) with background worker management (Workers).
+type serviceImpl interface {
+	Stop()
+	Workers() []*workers.Worker
+}
+
+// cbSvc is the ColdBrew service adapter. It delegates to the service
+// implementation in service/service.go. Optional interfaces (CBPreStarter,
+// CBWorkerProvider, etc.) are discovered automatically by ColdBrew's Run().
 type cbSvc struct {
-	stopper core.CBStopper
+	impl serviceImpl
 }
 
 // FailCheck allows graceful termination of the service
@@ -46,9 +58,20 @@ func (s *cbSvc) FailCheck(fail bool) {
 // Stop is called when the service is being stopped by the ColdBrew framework
 // This is a good place to clean up resources and gracefully shutdown the service if needed before the process exits completely
 func (s *cbSvc) Stop() {
-	s.stopper.Stop()
+	s.impl.Stop()
+}
 
-	// Add your additional cleanup code here if needed
+// PreStart is called before gRPC/HTTP servers start. Use this for setup that
+// must complete before accepting traffic: auth interceptors, database
+// connections, interceptor configuration, etc. Returning an error aborts startup.
+func (s *cbSvc) PreStart(ctx context.Context) error {
+	auth.Setup(ctx, config.Get().AuthConfig)
+	return nil
+}
+
+// Workers delegates to the service implementation which owns its background workers.
+func (s *cbSvc) Workers() []*workers.Worker {
+	return s.impl.Workers()
 }
 
 // InitHTTP is called by the ColdBrew framework to initialize the HTTP server and register the HTTP handlers
@@ -75,8 +98,7 @@ func (s *cbSvc) InitGRPC(ctx context.Context, server *grpc.Server) error {
 	// Register the health check service implementation with the gRPC server so that the gRPC health check endpoint is available
 	healthgrpc.RegisterHealthServer(server, impl)
 
-	// register stopper
-	s.stopper = impl
+	s.impl = impl
 	return nil
 }
 
@@ -123,10 +145,6 @@ func main() {
 	}
 	// Set the release name to the git commit hash from the version package
 	cfg.ReleaseName = version.GitCommit
-
-	// Register auth interceptors if JWT_SECRET or API_KEYS env vars are set.
-	// See service/auth/auth.go and https://docs.coldbrew.cloud/howto/auth/
-	auth.Setup(context.Background(), config.Get().AuthConfig)
 
 	// Initialize the ColdBrew framework with the given configuration
 	// This is a good place to customise the ColdBrew framework configuration if needed

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -94,8 +95,17 @@ func (s *cbSvc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint st
 // InitGRPC registers the service with the gRPC server.
 // The service impl is created in PreStart — InitGRPC just registers it.
 func (s *cbSvc) InitGRPC(ctx context.Context, server *grpc.Server) error {
-	{{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}Server(server, s.impl)
-	healthgrpc.RegisterHealthServer(server, s.impl)
+	svcServer, ok := s.impl.({{cookiecutter.app_name|lower}}.{{cookiecutter.service_name}}Server)
+	if !ok {
+		return errors.New("service impl does not implement {{cookiecutter.service_name}}Server")
+	}
+	{{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}Server(server, svcServer)
+
+	healthServer, ok := s.impl.(healthgrpc.HealthServer)
+	if !ok {
+		return errors.New("service impl does not implement HealthServer")
+	}
+	healthgrpc.RegisterHealthServer(server, healthServer)
 	return nil
 }
 

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -12,6 +12,7 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/auth"
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/version"
 	"github.com/go-coldbrew/core"
+	"github.com/go-coldbrew/workers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/swaggest/swgui"
 	"github.com/swaggest/swgui/v5emb"

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -61,10 +61,18 @@ func (s *cbSvc) Stop() {
 	s.impl.Stop()
 }
 
-// PreStart is called before gRPC/HTTP servers start. Use this for setup that
-// must complete before accepting traffic: auth interceptors, database
-// connections, interceptor configuration, etc. Returning an error aborts startup.
+// PreStart is called before gRPC/HTTP servers start. Use this for initialization
+// that must complete before accepting traffic: creating the service impl,
+// auth interceptors, database connections, etc. Returning an error aborts startup.
 func (s *cbSvc) PreStart(ctx context.Context) error {
+	impl, err := service.New(config.Get())
+	if err != nil {
+		return err
+	}
+	s.impl = impl
+
+	// Register auth interceptors (JWT_SECRET or API_KEYS env vars to enable).
+	// See service/auth/auth.go and https://docs.coldbrew.cloud/howto/auth/
 	auth.Setup(ctx, config.Get().AuthConfig)
 	return nil
 }
@@ -83,22 +91,11 @@ func (s *cbSvc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint st
 	return {{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}HandlerFromEndpoint(ctx, mux, endpoint, opts)
 }
 
-// InitGRPC is called by the ColdBrew framework to initialize the gRPC server and register the gRPC handlers
-// This is a good place to register your gRPC handlers if you have any custom handlers that you want to register with the gRPC server
-// If you are using the grpc-gateway, you can use the RegisterMySvcHandlerFromEndpoint function to register the HTTP handlers
+// InitGRPC registers the service with the gRPC server.
+// The service impl is created in PreStart — InitGRPC just registers it.
 func (s *cbSvc) InitGRPC(ctx context.Context, server *grpc.Server) error {
-	// Create the service implementation
-	impl, err := service.New(config.Get())
-	if err != nil {
-		return err
-	}
-	// Register the service implementation with the gRPC server
-	{{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}Server(server, impl)
-
-	// Register the health check service implementation with the gRPC server so that the gRPC health check endpoint is available
-	healthgrpc.RegisterHealthServer(server, impl)
-
-	s.impl = impl
+	{{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}Server(server, s.impl)
+	healthgrpc.RegisterHealthServer(server, s.impl)
 	return nil
 }
 

--- a/{{cookiecutter.app_name}}/main.go
+++ b/{{cookiecutter.app_name}}/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -13,6 +13,7 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/auth"
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/version"
 	"github.com/go-coldbrew/core"
+	"github.com/go-coldbrew/errors"
 	"github.com/go-coldbrew/workers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/swaggest/swgui"
@@ -63,7 +64,9 @@ func (s *cbSvc) Stop() {
 // that must complete before accepting traffic: creating the service impl,
 // auth interceptors, database connections, etc. Returning an error aborts startup.
 func (s *cbSvc) PreStart(ctx context.Context) error {
-	impl, err := service.New(config.Get())
+	cfg := config.Get()
+
+	impl, err := service.New(cfg)
 	if err != nil {
 		return err
 	}
@@ -71,7 +74,7 @@ func (s *cbSvc) PreStart(ctx context.Context) error {
 
 	// Register auth interceptors (JWT_SECRET or API_KEYS env vars to enable).
 	// See service/auth/auth.go and https://docs.coldbrew.cloud/howto/auth/
-	auth.Setup(ctx, config.Get().AuthConfig)
+	auth.Setup(ctx, cfg.AuthConfig)
 	return nil
 }
 
@@ -95,15 +98,19 @@ func (s *cbSvc) InitHTTP(ctx context.Context, mux *runtime.ServeMux, endpoint st
 // InitGRPC registers the service with the gRPC server.
 // The service impl is created in PreStart — InitGRPC just registers it.
 func (s *cbSvc) InitGRPC(ctx context.Context, server *grpc.Server) error {
+	if s.impl == nil {
+		return errors.New("nil service implementation; PreStart not run")
+	}
+
 	svcServer, ok := s.impl.({{cookiecutter.app_name|lower}}.{{cookiecutter.service_name}}Server)
 	if !ok {
-		return errors.New("service impl does not implement {{cookiecutter.service_name}}Server")
+		return errors.Wrap(fmt.Errorf("expected {{cookiecutter.service_name}}Server, got %T", s.impl), "InitGRPC")
 	}
 	{{cookiecutter.app_name|lower}}.Register{{cookiecutter.service_name}}Server(server, svcServer)
 
 	healthServer, ok := s.impl.(healthgrpc.HealthServer)
 	if !ok {
-		return errors.New("service impl does not implement HealthServer")
+		return errors.Wrap(fmt.Errorf("expected HealthServer, got %T", s.impl), "InitGRPC")
 	}
 	healthgrpc.RegisterHealthServer(server, healthServer)
 	return nil

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -9,11 +9,12 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/config"
 	proto "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/proto"
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/metrics"
-	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/genproto/googleapis/api/httpbody"
 	"github.com/go-coldbrew/errors"
 	cblog "github.com/go-coldbrew/log"
+	"github.com/go-coldbrew/workers"
+	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc/health"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // svc should implement the service interface defined in the proto file
@@ -78,7 +79,28 @@ func (s *svc) Stop() {
 	// Close database connections, flush buffers, etc.
 }
 
-// Creates a new Service instance and returns it
+// Workers returns background workers managed by ColdBrew via CBWorkerProvider.
+// Workers are started alongside gRPC/HTTP servers with automatic panic recovery
+// and configurable restart. Add your periodic tasks and long-running consumers here.
+func (s *svc) Workers() []*workers.Worker {
+	return []*workers.Worker{
+		workers.NewWorker("cleanup").
+			HandlerFunc(s.cleanup).
+			Every(5 * time.Minute).
+			WithJitter(10),
+		// Uncomment to add a queue consumer:
+		// workers.NewWorker("queue-consumer").HandlerFunc(s.consumeMessages),
+	}
+}
+
+func (s *svc) cleanup(ctx context.Context, info *workers.WorkerInfo) error {
+	slog.LogAttrs(ctx, slog.LevelInfo, "running periodic cleanup")
+	// TODO: Add your cleanup logic here (e.g., purge expired sessions, compact data)
+	return nil
+}
+
+// New creates a new Service instance and returns it
+// New creates a new Service instance and returns it
 func New(cfg config.Config) (*svc, error) {
 	// TODO: Application should validate the config here and return an error if it is invalid or missing
 	s := &svc{

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -100,7 +100,6 @@ func (s *svc) cleanup(ctx context.Context, info *workers.WorkerInfo) error {
 }
 
 // New creates a new Service instance and returns it
-// New creates a new Service instance and returns it
 func New(cfg config.Config) (*svc, error) {
 	// TODO: Application should validate the config here and return an error if it is invalid or missing
 	s := &svc{

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -17,8 +17,12 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// svc should implement the service interface defined in the proto file
-var _ proto.{{cookiecutter.service_name}}Server = (*svc)(nil)
+// Compile-time interface checks — remove or adjust as you customize your service.
+var (
+	_ proto.{{cookiecutter.service_name}}Server         = (*svc)(nil)
+	_ interface{ Stop() }                      = (*svc)(nil)
+	_ interface{ Workers() []*workers.Worker } = (*svc)(nil)
+)
 
 // Service interface for the service
 type svc struct {

--- a/{{cookiecutter.app_name}}/service/service_test.go
+++ b/{{cookiecutter.app_name}}/service/service_test.go
@@ -76,6 +76,15 @@ func TestError(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestWorkers(t *testing.T) {
+	s, err := New(config.Get())
+	assert.NoError(t, err)
+
+	w := s.Workers()
+	assert.NotEmpty(t, w, "Workers() should return at least one worker")
+	assert.Equal(t, "cleanup", w[0].GetName(), "first worker should be named 'cleanup'")
+}
+
 func BenchmarkEcho(b *testing.B) {
 	const prefix = "testPrefix"
 	const msg = "hello"

--- a/{{cookiecutter.app_name}}/service/service_test.go
+++ b/{{cookiecutter.app_name}}/service/service_test.go
@@ -82,7 +82,15 @@ func TestWorkers(t *testing.T) {
 
 	w := s.Workers()
 	assert.NotEmpty(t, w, "Workers() should return at least one worker")
-	assert.Equal(t, "cleanup", w[0].GetName(), "first worker should be named 'cleanup'")
+
+	var found bool
+	for _, worker := range w {
+		if worker.GetName() == "cleanup" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Workers() should include a worker named 'cleanup'")
 }
 
 func BenchmarkEcho(b *testing.B) {


### PR DESCRIPTION
## Summary

- Add `CBPreStarter` and `CBWorkerProvider` to `cbSvc` in `main.go`
- Move `auth.Setup()` from `main()` to `PreStart()` — runs before interceptor chain is built
- Add `Workers()` + example `cleanup()` handler to `service/service.go`
- Define local `serviceImpl` composite interface (`Stop` + `Workers`) for clean delegation without exporting the service type
- `svc` stays unexported — delegation works via the composite interface

## Depends on

- go-coldbrew/core#85 (workers + lifecycle hooks)

## Test plan

- [ ] Generate a project from the template and verify it compiles
- [ ] Verify `auth.Setup` runs in `PreStart` before servers start
- [ ] Verify workers start alongside gRPC/HTTP servers
- [ ] Verify existing tests still pass after `svc` type unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds periodic background worker management with a "cleanup" task running roughly every 5 minutes.
  * Refines service lifecycle: initialization now occurs in a pre-start phase; stop and worker discovery are delegated to the service implementation when supported.

* **Tests**
  * Adds unit test coverage for worker management, verifying worker presence and the "cleanup" worker name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->