### PR TITLE
feat: streaming RPC example with SSE support

### DIFF
--- a/{{cookiecutter.app_name}}/AGENTS.md
+++ b/{{cookiecutter.app_name}}/AGENTS.md
@@ -83,6 +83,40 @@ make run-docker      # Run in Docker container
 4. Add tests in `service/service_test.go`
 5. Run `make test` and `make lint`
 
+### Adding a streaming endpoint (SSE / AI/LLM tokens)
+
+Server-streaming RPCs are exposed by the HTTP gateway as newline-delimited JSON by default, or Server-Sent Events when the client sends `Accept: text/event-stream`. SSE support is enabled by ColdBrew out of the box (set `DISABLE_SSE_MARSHALER=true` to opt out), and the compression wrapper auto-excludes `text/event-stream` so frames are not buffered by gzip.
+
+1. Define a server-streaming RPC:
+   ```protobuf
+   rpc MyStream(MyRequest) returns (stream MyEvent) {
+     option (google.api.http) = {
+       post: "/api/v1/my-stream"
+       body: "*"
+     };
+   }
+   ```
+2. Implement using `grpc.ServerStreamingServer[MyEvent]`:
+   ```go
+   func (s *svc) MyStream(req *proto.MyRequest, stream grpc.ServerStreamingServer[proto.MyEvent]) error {
+       ctx := stream.Context()
+       for event := range produce(ctx, req) {
+           if err := ctx.Err(); err != nil {
+               return errors.Wrap(err, "my_stream canceled")
+           }
+           if err := stream.Send(event); err != nil {
+               return errors.Wrap(err, "my_stream send")
+           }
+       }
+       return nil
+   }
+   ```
+3. **Always check `stream.Context().Err()` before each Send.** Client disconnect cancels the context — for AI/LLM workloads this is the signal to stop generating (and stop paying for) tokens. Pass the context into your LLM SDK call so cancellation propagates to the upstream provider.
+4. Track time-to-first-token (TTFT) as a separate metric from total stream duration — TTFT surfaces upstream latency independently of generation throughput. See `IncStreamEchoTotal` / `ObserveStreamEchoTTFT` in `service/metrics/` for the pattern.
+5. The `StreamEcho` RPC in the generated proto is a synthetic example — replace its body with your real streaming source (LLM SDK, change-data-capture feed, progress events, etc.) or delete it once you have your own streams.
+
+> **Gateway message wrapping.** grpc-gateway wraps each streamed message in `{"result": <message>}` over HTTP — this is the gateway's documented convention for server-streaming responses. Native gRPC clients see the unwrapped message. Use `google.api.HttpBody` as the stream response type if you need full control over the wire bytes for SSE consumers.
+
 ### Adding configuration
 
 1. Add a field to the `Config` struct in `config/config.go` with an `envconfig` tag:

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -83,6 +83,29 @@ The file `service/service.go` contains the implementation of the API and serves 
 
 We use [grpc-gateway] to automatically map HTTP requests to gRPC requests. You can find the mapping in the `proto/{{cookiecutter.app_name|lower}}.proto` file. This server is generated according to [custom options](https://cloud.google.com/service-infrastructure/docs/service-management/reference/rpc/google.api#http) in your gRPC definition.  You can find more information about the mapping [here](https://grpc-ecosystem.github.io/grpc-gateway/docs/tutorials/adding_annotations/)
 
+### Streaming responses (Server-Sent Events)
+
+Server-streaming gRPC methods (e.g. `StreamEcho` in the generated proto) are exposed over the HTTP gateway in two formats based on the request's `Accept` header:
+
+- **Default — newline-delimited JSON.** One JSON object per line, suitable for `curl -N` or any HTTP client that reads line-by-line.
+- **`Accept: text/event-stream` — Server-Sent Events.** Standard SSE framing (`data: <json>\n\n`) consumable directly by a browser `EventSource(...)`. Enabled by ColdBrew out of the box (set `DISABLE_SSE_MARSHALER=true` to opt out). The HTTP compression wrapper automatically excludes `text/event-stream` so frames reach the client in real time.
+
+Try it against the generated `StreamEcho` example:
+
+```console
+$ # Newline-delimited JSON (one frame per line):
+$ curl -N -X POST -H 'Content-Type: application/json' \
+    -d '{"msg":"hello world foo"}' \
+    http://localhost:9091/api/v1/example/stream
+
+$ # Server-Sent Events (browser EventSource format):
+$ curl -N -X POST -H 'Content-Type: application/json' -H 'Accept: text/event-stream' \
+    -d '{"msg":"hello world foo"}' \
+    http://localhost:9091/api/v1/example/stream
+```
+
+This is the right transport for AI/LLM token streaming and other long-running progressive responses. Stream handlers must observe `stream.Context()` cancellation — client disconnect cancels the context, and your handler should stop producing (and stop paying for) further tokens. See `StreamEcho` in `service/service.go` for the pattern.
+
 ## Application configuration
 
 This project uses [envconfig] to manage configuration as environment variables. You can find the configuration struct in `config/config.go`. You can also find the default values in the `config/config.go` file.

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -12,7 +12,7 @@ tool (
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
-	github.com/go-coldbrew/core v0.2.0
+	github.com/go-coldbrew/core v0.2.3
 	github.com/go-coldbrew/errors v0.2.15
 	github.com/go-coldbrew/workers v0.2.1
 	github.com/go-coldbrew/interceptors v0.3.1

--- a/{{cookiecutter.app_name}}/proto/{{cookiecutter.app_name|lower}}.proto
+++ b/{{cookiecutter.app_name}}/proto/{{cookiecutter.app_name|lower}}.proto
@@ -64,6 +64,13 @@ message EchoResponse{
   string msg = 1;
 }
 
+// EchoToken is one frame of a StreamEcho response. Acts as a stand-in for an
+// LLM token, a progress event, or any other piece of a streaming response.
+message EchoToken{
+  string token = 1;
+  int32 index = 2;
+}
+
 service {{cookiecutter.service_name}} {
   //LivenessProbe for the service
   rpc HealthCheck(google.protobuf.Empty) returns (google.api.HttpBody) {
@@ -107,6 +114,23 @@ service {{cookiecutter.service_name}} {
       summary: "Error endpoint"
       description: "Request made to this endpoint result in errors."
       tags: "error"
+    };
+  }
+
+  // StreamEcho splits the input message into whitespace-separated tokens and
+  // emits one EchoToken per frame. Demonstrates server-streaming RPC over both
+  // native gRPC and the HTTP gateway (newline-delimited JSON by default, or
+  // text/event-stream when the client sends Accept: text/event-stream and the
+  // service registered core.SSEMarshaler — see main.go PreStart).
+  rpc StreamEcho(EchoRequest) returns (stream EchoToken) {
+    option (google.api.http) = {
+      post: "/api/v1/example/stream"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Streaming echo endpoint"
+      description: "Streams tokens of the input message, one frame at a time. Send Accept: text/event-stream for Server-Sent Events (browser EventSource), otherwise newline-delimited JSON."
+      tags: "echo"
     };
   }
 }

--- a/{{cookiecutter.app_name}}/proto/{{cookiecutter.app_name|lower}}.proto
+++ b/{{cookiecutter.app_name}}/proto/{{cookiecutter.app_name|lower}}.proto
@@ -119,9 +119,10 @@ service {{cookiecutter.service_name}} {
 
   // StreamEcho splits the input message into whitespace-separated tokens and
   // emits one EchoToken per frame. Demonstrates server-streaming RPC over both
-  // native gRPC and the HTTP gateway (newline-delimited JSON by default, or
-  // text/event-stream when the client sends Accept: text/event-stream and the
-  // service registered core.SSEMarshaler — see main.go PreStart).
+  // native gRPC and the HTTP gateway. The gateway emits newline-delimited JSON
+  // by default, or Server-Sent Events when the client sends
+  // Accept: text/event-stream (ColdBrew registers the SSE marshaler by
+  // default; set DISABLE_SSE_MARSHALER=true on core to opt out).
   rpc StreamEcho(EchoRequest) returns (stream EchoToken) {
     option (google.api.http) = {
       post: "/api/v1/example/stream"

--- a/{{cookiecutter.app_name}}/service/metrics/labels.go
+++ b/{{cookiecutter.app_name}}/service/metrics/labels.go
@@ -2,6 +2,7 @@ package metrics
 
 // Outcome label values for use with IncEchoTotal and similar methods.
 const (
-	OutcomeSuccess = "success"
-	OutcomeError   = "error"
+	OutcomeSuccess  = "success"
+	OutcomeError    = "error"
+	OutcomeCanceled = "canceled"
 )

--- a/{{cookiecutter.app_name}}/service/metrics/metrics.go
+++ b/{{cookiecutter.app_name}}/service/metrics/metrics.go
@@ -22,6 +22,26 @@ var (
 		Help:      "Duration of Echo RPC calls in seconds.",
 		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
 	}, []string{"outcome"})
+
+	streamEchoTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "stream_echo_total",
+		Help:      "Total number of StreamEcho RPC calls by outcome (success, error, canceled).",
+	}, []string{"outcome"})
+
+	streamEchoDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "stream_echo_duration_seconds",
+		Help:      "Total duration of StreamEcho RPC calls in seconds.",
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"outcome"})
+
+	streamEchoTTFT = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "stream_echo_ttft_seconds",
+		Help:      "Time to first token (TTFT) for StreamEcho RPC calls in seconds. Recorded only when at least one token is emitted.",
+		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+	})
 )
 
 type appMetrics struct{}
@@ -37,4 +57,16 @@ func (m *appMetrics) IncEchoTotal(outcome string) {
 
 func (m *appMetrics) ObserveEchoDuration(outcome string, duration time.Duration) {
 	echoDuration.WithLabelValues(outcome).Observe(duration.Seconds())
+}
+
+func (m *appMetrics) IncStreamEchoTotal(outcome string) {
+	streamEchoTotal.WithLabelValues(outcome).Inc()
+}
+
+func (m *appMetrics) ObserveStreamEchoDuration(outcome string, duration time.Duration) {
+	streamEchoDuration.WithLabelValues(outcome).Observe(duration.Seconds())
+}
+
+func (m *appMetrics) ObserveStreamEchoTTFT(duration time.Duration) {
+	streamEchoTTFT.Observe(duration.Seconds())
 }

--- a/{{cookiecutter.app_name}}/service/metrics/metrics_test.go
+++ b/{{cookiecutter.app_name}}/service/metrics/metrics_test.go
@@ -49,3 +49,45 @@ func TestObserveEchoDuration(t *testing.T) {
 		t.Fatal("expected at least one observation")
 	}
 }
+
+func TestIncStreamEchoTotal(t *testing.T) {
+	m := New()
+	m.IncStreamEchoTotal(OutcomeSuccess)
+	m.IncStreamEchoTotal(OutcomeCanceled)
+
+	mf := gatherMetric(t, namespace+"_stream_echo_total")
+	if mf == nil {
+		t.Fatal("metric not found")
+	}
+	if len(mf.GetMetric()) < 2 {
+		t.Fatalf("expected at least 2 label pairs (success + canceled), got %d", len(mf.GetMetric()))
+	}
+}
+
+func TestObserveStreamEchoDuration(t *testing.T) {
+	m := New()
+	m.ObserveStreamEchoDuration(OutcomeSuccess, 200*time.Millisecond)
+
+	mf := gatherMetric(t, namespace+"_stream_echo_duration_seconds")
+	if mf == nil {
+		t.Fatal("metric not found")
+	}
+	h := mf.GetMetric()[0].GetHistogram()
+	if h.GetSampleCount() == 0 {
+		t.Fatal("expected at least one observation")
+	}
+}
+
+func TestObserveStreamEchoTTFT(t *testing.T) {
+	m := New()
+	m.ObserveStreamEchoTTFT(10 * time.Millisecond)
+
+	mf := gatherMetric(t, namespace+"_stream_echo_ttft_seconds")
+	if mf == nil {
+		t.Fatal("metric not found")
+	}
+	h := mf.GetMetric()[0].GetHistogram()
+	if h.GetSampleCount() == 0 {
+		t.Fatal("expected at least one observation")
+	}
+}

--- a/{{cookiecutter.app_name}}/service/metrics/types.go
+++ b/{{cookiecutter.app_name}}/service/metrics/types.go
@@ -11,4 +11,12 @@ type Metrics interface {
 	// Echo RPC metrics
 	IncEchoTotal(outcome string)
 	ObserveEchoDuration(outcome string, duration time.Duration)
+
+	// StreamEcho RPC metrics. Time-to-first-token (TTFT) is the standard
+	// AI/LLM streaming metric — the gap between request arrival and the first
+	// emitted frame. Tracking it separately from total duration surfaces
+	// upstream-latency vs. generation-throughput issues independently.
+	IncStreamEchoTotal(outcome string)
+	ObserveStreamEchoDuration(outcome string, duration time.Duration)
+	ObserveStreamEchoTTFT(duration time.Duration)
 }

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/config"
@@ -13,6 +14,7 @@ import (
 	cblog "github.com/go-coldbrew/log"
 	"github.com/go-coldbrew/workers"
 	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -77,6 +79,60 @@ func (s *svc) Error(ctx context.Context, req *proto.EchoRequest) (*proto.EchoRes
 	err := errors.New("This is an Error")
 	slog.LogAttrs(ctx, slog.LevelInfo, "error requested")
 	return nil, errors.Wrap(err, "endpoint error")
+}
+
+// streamEchoFrameDelay paces frame emission so the streaming behavior is
+// visible end-to-end (browser EventSource, curl -N, grpcurl). For real
+// workloads — LLM tokens, progress events, etc. — remove the sleep and emit
+// frames as the upstream source produces them.
+const streamEchoFrameDelay = 50 * time.Millisecond
+
+// StreamEcho streams one EchoToken per whitespace-separated word in the
+// request message. Demonstrates server-streaming over both native gRPC and
+// the HTTP gateway (newline-delimited JSON by default, or Server-Sent Events
+// when core.SSEMarshaler is registered — see main.go PreStart).
+//
+// The Context check before each Send is the load-bearing piece for AI/LLM
+// workloads: client disconnect cancels stream.Context(), and the handler
+// must observe it to stop generating (and stop paying for) tokens.
+func (s *svc) StreamEcho(req *proto.EchoRequest, stream grpc.ServerStreamingServer[proto.EchoToken]) (err error) {
+	ctx := stream.Context()
+	start := time.Now()
+	outcome := metrics.OutcomeSuccess
+	defer func() {
+		if err != nil {
+			outcome = metrics.OutcomeError
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				outcome = metrics.OutcomeCanceled
+			}
+		}
+		s.monitoring.IncStreamEchoTotal(outcome)
+		s.monitoring.ObserveStreamEchoDuration(outcome, time.Since(start))
+	}()
+
+	tokens := strings.Fields(req.GetMsg())
+	ctx = cblog.AddAttrsToContext(ctx, slog.Int("stream_echo_tokens", len(tokens)))
+	slog.LogAttrs(ctx, slog.LevelInfo, "stream_echo requested")
+
+	for i, token := range tokens {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return errors.Wrap(ctxErr, "stream_echo canceled")
+		}
+
+		if err := stream.Send(&proto.EchoToken{
+			Token: fmt.Sprintf("%s: %s", s.prefix, token),
+			Index: int32(i),
+		}); err != nil {
+			return errors.Wrap(err, "stream_echo send")
+		}
+
+		if i == 0 {
+			s.monitoring.ObserveStreamEchoTTFT(time.Since(start))
+		}
+
+		time.Sleep(streamEchoFrameDelay)
+	}
+	return nil
 }
 
 func (s *svc) Stop() {

--- a/{{cookiecutter.app_name}}/service/service.go
+++ b/{{cookiecutter.app_name}}/service/service.go
@@ -15,7 +15,9 @@ import (
 	"github.com/go-coldbrew/workers"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -89,12 +91,14 @@ const streamEchoFrameDelay = 50 * time.Millisecond
 
 // StreamEcho streams one EchoToken per whitespace-separated word in the
 // request message. Demonstrates server-streaming over both native gRPC and
-// the HTTP gateway (newline-delimited JSON by default, or Server-Sent Events
-// when core.SSEMarshaler is registered — see main.go PreStart).
+// the HTTP gateway — the gateway emits newline-delimited JSON by default,
+// or Server-Sent Events when the client sends Accept: text/event-stream
+// (ColdBrew registers the SSE marshaler by default; set
+// DISABLE_SSE_MARSHALER=true on core to opt out).
 //
-// The Context check before each Send is the load-bearing piece for AI/LLM
-// workloads: client disconnect cancels stream.Context(), and the handler
-// must observe it to stop generating (and stop paying for) tokens.
+// Context cancellation is the load-bearing piece for AI/LLM workloads:
+// client disconnect cancels stream.Context(), and the handler must observe
+// it to stop generating (and stop paying for) tokens.
 func (s *svc) StreamEcho(req *proto.EchoRequest, stream grpc.ServerStreamingServer[proto.EchoToken]) (err error) {
 	ctx := stream.Context()
 	start := time.Now()
@@ -116,21 +120,32 @@ func (s *svc) StreamEcho(req *proto.EchoRequest, stream grpc.ServerStreamingServ
 
 	for i, token := range tokens {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return errors.Wrap(ctxErr, "stream_echo canceled")
+			return status.Error(codes.Canceled, fmt.Sprintf("stream_echo canceled: %v", ctxErr))
 		}
 
-		if err := stream.Send(&proto.EchoToken{
+		if sendErr := stream.Send(&proto.EchoToken{
 			Token: fmt.Sprintf("%s: %s", s.prefix, token),
 			Index: int32(i),
-		}); err != nil {
-			return errors.Wrap(err, "stream_echo send")
+		}); sendErr != nil {
+			// Preserve the canonical gRPC code when grpc-go already wrapped
+			// the error (e.g. Canceled / Unavailable on client disconnect).
+			if _, ok := status.FromError(sendErr); ok {
+				return sendErr
+			}
+			return status.Error(codes.Internal, fmt.Sprintf("stream_echo send: %v", sendErr))
 		}
 
 		if i == 0 {
 			s.monitoring.ObserveStreamEchoTTFT(time.Since(start))
 		}
 
-		time.Sleep(streamEchoFrameDelay)
+		// ctx-aware pacing: a client disconnect during the artificial delay
+		// must stop the handler immediately, not wait for the next iteration.
+		select {
+		case <-time.After(streamEchoFrameDelay):
+		case <-ctx.Done():
+			return status.Error(codes.Canceled, fmt.Sprintf("stream_echo canceled: %v", ctx.Err()))
+		}
 	}
 	return nil
 }

--- a/{{cookiecutter.app_name}}/service/service_test.go
+++ b/{{cookiecutter.app_name}}/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -10,6 +11,8 @@ import (
 	"{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/service/metrics"
 	mockmetrics "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/misc/mocks/metrics"
 	proto "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestNew(t *testing.T) {
@@ -91,6 +94,82 @@ func TestWorkers(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "Workers() should include a worker named 'cleanup'")
+}
+
+// fakeStreamEchoServer is a minimal grpc.ServerStreamingServer[proto.EchoToken]
+// for unit-testing StreamEcho without a real gRPC connection. Tracks tokens
+// sent via Send so tests can assert ordering and payload, and exposes a
+// pluggable Context so tests can simulate client disconnect.
+type fakeStreamEchoServer struct {
+	grpc.ServerStream
+	ctx  context.Context
+	sent []*proto.EchoToken
+}
+
+func (f *fakeStreamEchoServer) Context() context.Context { return f.ctx }
+
+func (f *fakeStreamEchoServer) Send(t *proto.EchoToken) error {
+	f.sent = append(f.sent, t)
+	return nil
+}
+
+func (f *fakeStreamEchoServer) SetHeader(metadata.MD) error  { return nil }
+func (f *fakeStreamEchoServer) SendHeader(metadata.MD) error { return nil }
+func (f *fakeStreamEchoServer) SetTrailer(metadata.MD)       {}
+
+func TestStreamEcho(t *testing.T) {
+	const prefix = "testPrefix"
+	const msg = "hello world foo"
+
+	m := mockmetrics.NewMetrics(t)
+	m.EXPECT().IncStreamEchoTotal(metrics.OutcomeSuccess).Once()
+	m.EXPECT().ObserveStreamEchoDuration(metrics.OutcomeSuccess, mock.AnythingOfType("time.Duration")).Once()
+	m.EXPECT().ObserveStreamEchoTTFT(mock.AnythingOfType("time.Duration")).Once()
+
+	s := &svc{
+		Server:     GetHealthCheckServer(),
+		monitoring: m,
+		prefix:     prefix,
+	}
+
+	stream := &fakeStreamEchoServer{ctx: context.Background()}
+	err := s.StreamEcho(&proto.EchoRequest{Msg: msg}, stream)
+	assert.NoError(t, err)
+
+	assert.Len(t, stream.sent, 3, "one frame per whitespace-separated word")
+	for i, want := range []string{prefix + ": hello", prefix + ": world", prefix + ": foo"} {
+		assert.Equal(t, want, stream.sent[i].GetToken(), "frame %d token", i)
+		assert.Equal(t, int32(i), stream.sent[i].GetIndex(), "frame %d index", i)
+	}
+}
+
+func TestStreamEcho_ContextCanceledMidStream(t *testing.T) {
+	const prefix = "testPrefix"
+	const msg = "hello world foo bar"
+
+	m := mockmetrics.NewMetrics(t)
+	m.EXPECT().IncStreamEchoTotal(metrics.OutcomeCanceled).Once()
+	m.EXPECT().ObserveStreamEchoDuration(metrics.OutcomeCanceled, mock.AnythingOfType("time.Duration")).Once()
+	m.EXPECT().ObserveStreamEchoTTFT(mock.AnythingOfType("time.Duration")).Maybe()
+
+	s := &svc{
+		Server:     GetHealthCheckServer(),
+		monitoring: m,
+		prefix:     prefix,
+	}
+
+	// Cancel the context after a short delay — long enough to emit a frame or
+	// two but not enough to finish the four-token stream (each frame waits
+	// streamEchoFrameDelay before the next iteration). Asserting the handler
+	// stops generating mid-stream is the load-bearing safety property for
+	// AI/LLM workloads: client disconnect must halt token production.
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(streamEchoFrameDelay/2, cancel)
+
+	stream := &fakeStreamEchoServer{ctx: ctx}
+	err := s.StreamEcho(&proto.EchoRequest{Msg: msg}, stream)
+	assert.Error(t, err, "StreamEcho should return error when context is canceled")
+	assert.Less(t, len(stream.sent), 4, "handler should stop emitting after cancel")
 }
 
 func BenchmarkEcho(b *testing.B) {

--- a/{{cookiecutter.app_name}}/service/service_test.go
+++ b/{{cookiecutter.app_name}}/service/service_test.go
@@ -12,7 +12,9 @@ import (
 	mockmetrics "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/misc/mocks/metrics"
 	proto "{{cookiecutter.source_path}}/{{cookiecutter.app_name}}/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestNew(t *testing.T) {
@@ -169,6 +171,7 @@ func TestStreamEcho_ContextCanceledMidStream(t *testing.T) {
 	stream := &fakeStreamEchoServer{ctx: ctx}
 	err := s.StreamEcho(&proto.EchoRequest{Msg: msg}, stream)
 	assert.Error(t, err, "StreamEcho should return error when context is canceled")
+	assert.Equal(t, codes.Canceled, status.Code(err), "cancellation must surface as gRPC codes.Canceled")
 	assert.Less(t, len(stream.sent), 4, "handler should stop emitting after cancel")
 }
 


### PR DESCRIPTION
## Summary

- Adds `StreamEcho` — a server-streaming RPC alongside the existing `Echo`/`Error` examples — that splits the request message into whitespace-separated tokens and emits one `EchoToken` per frame. Acts as a stand-in for AI/LLM token streaming, progress events, or any progressive response.
- Demonstrates production streaming patterns: context-cancellation check before every `Send` (stops generating on client disconnect, critical for LLM workloads), time-to-first-token (TTFT) tracked as a distinct metric, and per-outcome counters including `OutcomeCanceled`.
- README and AGENTS.md updated with curl + EventSource examples and a streaming-endpoint recipe.

Browser `EventSource` consumption works out of the box: [`go-coldbrew/core` PR #92](https://github.com/go-coldbrew/core/pull/92) registers a `text/event-stream` marshaler by default, so any server-streaming gateway RPC is SSE-consumable when the client sends `Accept: text/event-stream`. No service-side wiring needed — `DISABLE_SSE_MARSHALER=true` opts out.

## Test plan

- [x] `tox -e py313` — cookiecutter structure tests 58/58 passing.
- [x] Generated project (`cookiecutter --no-input` + post-gen hooks) builds clean with `go build ./...` against local core SSE branch.
- [x] Generated project's `go test -race ./service/...` passes — covers `StreamEcho` happy path (3 tokens in/out, index ordering) and mid-stream cancellation (handler returns before all tokens emitted).
- [ ] **Depends on** [core#92](https://github.com/go-coldbrew/core/pull/92) — after merge + tag, follow-up commit will bump `core` in template `go.mod` so the `DISABLE_SSE_MARSHALER` env var is recognized. The streaming RPC itself works against the current pinned `core v0.2.0` (just without the opt-out flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-streaming example that emits token frames incrementally via the HTTP gateway.
  * Streaming over HTTP now supports SSE (`text/event-stream`) in addition to newline-delimited JSON.
* **Documentation**
  * Expanded guidance for implementing streaming RPCs, including cancellation handling and SSE behavior.
* **Bug Fixes**
  * Improved streaming observability by tracking success, error, and canceled outcomes separately.
* **Tests**
  * Added unit tests for streaming delivery and mid-stream context cancellation, plus stream-related metrics coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->